### PR TITLE
Fix selection of Apple target OS

### DIFF
--- a/physx/include/foundation/PxPreprocessor.h
+++ b/physx/include/foundation/PxPreprocessor.h
@@ -99,10 +99,15 @@ Operating system defines, see http://sourceforge.net/p/predef/wiki/OperatingSyst
 	#define PX_ANDROID 1
 #elif defined(__linux__) || defined (__EMSCRIPTEN__) // note: __ANDROID__ implies __linux__
 	#define PX_LINUX 1
-#elif defined(__APPLE__) && (defined(__arm__) || defined(__arm64__))
-	#define PX_IOS 1
 #elif defined(__APPLE__)
-	#define PX_OSX 1
+	#include <TargetConditionals.h>
+	#if TARGET_OS_IPHONE
+		#define PX_IOS 1
+	#elif TARGET_OS_OSX
+		#define PX_OSX 1
+	#else
+		#error "Unknown Apple target OS"
+	#endif
 #elif defined(__NX__)
 	#define PX_SWITCH 1
 #else


### PR DESCRIPTION
Arm-based Mac were selected as IOS targets. Now it's fixed.

Tested building PhysX 5 for iOS, Mac and Mac-arm.

Signed-off-by: moraaar <moraaar@amazon.com>

