### PR TITLE
Add CODEOWNERS file for O3DE fork of PhysX

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/* @o3de/sig-simulation-reviewers @o3de/sig-simulation-maintainers


### PR DESCRIPTION
FYI I do see this when looking at my own fork, but I think things will work correctly when merged back to the PhysX fork under the O3DE organization

![image](https://user-images.githubusercontent.com/82228511/215094645-73fe70f8-406c-4cd6-ada2-4c3f3909ce7e.png)

Signed-off-by: Tom Hulton-Harrop <82228511+hultonha@users.noreply.github.com>
